### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/fastAutoTest/core/common/network/shortLiveWebSocket.py
+++ b/fastAutoTest/core/common/network/shortLiveWebSocket.py
@@ -7,6 +7,7 @@ https://opensource.org/licenses/BSD-3-Clause
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 '''
+from __future__ import print_function
 import json
 import threading
 import time
@@ -105,7 +106,7 @@ class ShortLiveWebSocket(DataTransferCallback):
 
             except WebSocketConnectionClosedException:
                 if self.isQuit():
-                    print 'already quit'
+                    print('already quit')
                 else:
                     pass
             except Exception:

--- a/fastAutoTest/core/h5/h5Engine.py
+++ b/fastAutoTest/core/h5/h5Engine.py
@@ -34,8 +34,11 @@ from fastAutoTest.utils.logger import Log
 
 import sys
 
-reload(sys)
-sys.setdefaultencoding('utf8')
+try:
+    reload(sys)
+    sys.setdefaultencoding('utf8')
+except NameError:
+    pass
 
 __all__ = [
     "H5Driver"

--- a/fastAutoTest/core/h5/h5PageOperator.py
+++ b/fastAutoTest/core/h5/h5PageOperator.py
@@ -54,7 +54,10 @@ class H5PageOperator(object):
         commandList.append(keydownCommand)
 
         # textEvent的command,需要将字符串分割成每四个字符为一小段
-        unicodeText = unicode(text, 'utf-8')
+        try:
+            unicodeText = unicode(text, 'utf-8')
+        except NameError:
+            unicodeText = str(text)
         length = len(unicodeText)
         i = length / 4 if length % 4 == 0 else length / 4 + 1
         for j in range(i):

--- a/fastAutoTest/core/qq/qqEngine.py
+++ b/fastAutoTest/core/qq/qqEngine.py
@@ -28,8 +28,12 @@ from fastAutoTest.utils.singlethreadexecutor import SingleThreadExecutor
 from fastAutoTest.utils.vmhook import VMShutDownHandler, UncaughtExceptionHandler
 from qqWebSocketDebugUrlFetcher import QQWebSocketDebugUrlFetcher
 
-reload(sys)
-sys.setdefaultencoding('utf8')
+try:
+    reload(sys)
+    sys.setdefaultencoding('utf8')
+except NameError:
+    pass
+
 __all__ = {
     "QQDriver"
 }

--- a/fastAutoTest/core/wx/wxEngine.py
+++ b/fastAutoTest/core/wx/wxEngine.py
@@ -29,8 +29,12 @@ from fastAutoTest.utils.logger import Log
 from fastAutoTest.utils.singlethreadexecutor import SingleThreadExecutor
 from fastAutoTest.utils.vmhook import VMShutDownHandler, UncaughtExceptionHandler
 
-reload(sys)
-sys.setdefaultencoding('utf8')
+try:
+    reload(sys)
+    sys.setdefaultencoding('utf8')
+except NameError:
+    pass
+
 __all__ = {
     "WxDriver"
 }

--- a/fastAutoTest/core/wx/wxWebSocketDebugUrlFetcher.py
+++ b/fastAutoTest/core/wx/wxWebSocketDebugUrlFetcher.py
@@ -7,6 +7,7 @@ https://opensource.org/licenses/BSD-3-Clause
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 '''
+from __future__ import print_function
 
 import json
 import urllib2
@@ -267,7 +268,7 @@ class WxWebSocketDebugUrlFetcher(object):
             url = ''
             for url in serviceUrlList:
                 webSocketUrl = responseWesocketUrlDict.get(url)
-                print webSocketUrl
+                print(webSocketUrl)
                 webSocketConn = create_connection(url=webSocketUrl)
                 webSocketConn.send(
                     '{"id": 1,"method": "Runtime.evaluate","params": {"expression": "srcs = document.body.childNodes[0].getAttribute(\'src\')"}}'

--- a/fastAutoTest/utils/commandHelper.py
+++ b/fastAutoTest/utils/commandHelper.py
@@ -7,6 +7,7 @@ https://opensource.org/licenses/BSD-3-Clause
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 '''
+from __future__ import print_function
 import subprocess
 
 from fastAutoTest.core.common.errormsgmanager import *
@@ -32,5 +33,5 @@ def runCommand(cmd, printDetails=False, cwd=None):
 if __name__ == "__main__":
     cmd = "adb forward tcp:%s localabstract:webview_devtools_remote_%s" % (9222, 123)
     out, error = runCommand(cmd)
-    print(error == "")
-    print out
+    print((error == ""))
+    print(out)


### PR DESCRIPTION
These changes are compatible with both Python2 and Python 3.
* __print()__ is a function in Python 3.
* __unicode()__ was removed in Python 3 because all __str__ are utf-8 Unicode.
* __reload()__ and __sys.setdefaultencoding()__ were removed in Python 3 because the default is utf-8 Unicode.