### PR TITLE
Fix a setDebugLogMode not available bug

### DIFF
--- a/fastAutoTest/utils/logger.py
+++ b/fastAutoTest/utils/logger.py
@@ -16,8 +16,18 @@ class Log(object):
     WARNING = logging.WARNING
     ERROR = logging.ERROR
     CRITICAL = logging.CRITICAL
+    _instance = None
+    
+    """
+    单例模式
+    """
+    def __new__(cls, *args, **kwargs):
+        if cls._instance is None:
+            cls._instance = super(Log, cls).__new__(cls, *args, **kwargs)
+            cls._instance.init()
+        return cls._instance
 
-    def __init__(self, name='default'):
+    def init(self, name='default'):
         self.name = name
         self.logger = logging.getLogger(self.name)
         self.logger.setLevel(self.INFO)


### PR DESCRIPTION
`wxDriver.setDebugLogMode()` is not available to open the DebugLogMode because the `wxDriver.logger.level` will be reset to **logging.INFO** when `utils.logger.Log()` is called every time.